### PR TITLE
Fix empty config crash

### DIFF
--- a/lib/sfctl/commands/time/sync.rb
+++ b/lib/sfctl/commands/time/sync.rb
@@ -21,7 +21,7 @@ module Sfctl
         def execute(output: $stdout)
           return if !config_present?(output) || !link_config_present?(output)
 
-          if read_link_config['connections'].length.zero?
+          if connections.length.zero?
             output.puts @pastel.red('Please add a connection before continue.')
             return
           end
@@ -34,8 +34,12 @@ module Sfctl
 
         private
 
+        def connections
+          @connections ||= read_link_config.fetch('connections', [])
+        end
+
         def assignments_from_connections
-          read_link_config['connections'].map do |con|
+          connections.map do |con|
             id = con[0]
             asmnt = con[1]
             {
@@ -70,7 +74,7 @@ module Sfctl
         def sync_assignments(output, list)
           list.each do |assignment|
             assignment_id = assignment['id'].to_s
-            connection = read_link_config['connections'].select { |c| c == assignment_id }
+            connection = connections.select { |c| c == assignment_id }
             sync(output, assignment, connection[assignment_id])
           end
         end

--- a/spec/unit/time/sync_spec.rb
+++ b/spec/unit/time/sync_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Sfctl::Commands::Time::Sync, type: :unit do
 
     ::FileUtils.touch tmp_path(link_config_file)
     expect(File.file?(tmp_path(link_config_file))).to be_truthy
-    File.write tmp_path(link_config_file), "---\nconnections: {}"
+    File.write tmp_path(link_config_file), '--- {}'
 
     described_class.new(options).execute(output: output)
     expect(output.string).to include 'Please add a connection before continue.'


### PR DESCRIPTION
## Steps to reproduce

```
sfctl time init
sfctl time sync
```

## Actual result

```
     NoMethodError:
       undefined method `length' for nil:NilClass
     # ./lib/sfctl/commands/time/sync.rb:24:in `execute'
     # ./spec/unit/time/sync_spec.rb:202:in `block (2 levels) in <top (required)>'
```

## Expected result

Error message "Please add a connection before continue."